### PR TITLE
Docs: Adds Alerts Markdown support

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,3 +57,5 @@ YouTranslate utilizes ElevenLabs' voice cloning API and 'googletrans' python lib
 ## :medical_symbol: Contributing
 
 Contributions to YouTranslate are welcome! If you find any issues or want to improve the script, feel free to submit a pull request. For major changes or new features, please open an issue first to discuss the proposed changes.
+
+For more info, check out [**CONTRIBUTING.md**](./docs/CONTRIBUTING.md)

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,9 +1,9 @@
 # 📜 Conventions for contributions
 This file contains guidelines for creating *commits, PRs, branches, issues, and etc*. 
-<br>
-**READ BEFORE CONTRIBUTING!**
-<br>
-If you have any questions on the following information, text me (Adil), I will take you through it.
+
+> [!NOTE]  
+> **READ BEFORE CONTRIBUTING!**<br>
+> If you have any questions on the following information, text me (Adil), I will take you through it.
 
 ## ➕ Commits
 First, let's answer the questions **"When do I commit? And how many files do I commit at once?"**
@@ -11,10 +11,13 @@ First, let's answer the questions **"When do I commit? And how many files do I c
 The answer is very simple! Commit anytime you are done with ANY task. **For ex:**
 <br>
 <br>
-Let's say you are adding a login page. That's a big task, so you divide it on small ***sub-tasks***. (Make a login box, make a button, connect firebase, and etc.) Everytime you are done with a subtask, make a commit! 
-<br>
-<br>
-**!!ATTENTION!!** Please, don't stage all the files in one commit. Stage only the files that are relevant to the subtask you finished. This is going to be unbelievably helpful down the road.
+Let's say you are adding a login page. That's a big task, so you divide it on small ***sub-tasks***. (Make a login box, make a button, connect firebase, and etc.)
+
+Everytime you are done with a subtask, make a commit! 
+
+> [!WARNING] 
+> Please, don't stage all the files in one commit. Stage only the files that are relevant to the subtask you finished.<br>
+> This is going to be unbelievably helpful down the road.
 
 ### 🗃️ Commit message Structure
 ---
@@ -53,7 +56,8 @@ If there is a breaking change, put "BREAKING CHANGE:" in your ***commit body***,
 
 ## 🌳 Branching
 Try to have 1 branch per 1 issue. When you take up an issue (task) to work on, assign it to yourself on the issue's page, and comment: "@AdiKsOnDev, I am working on this issue."
-<br>
+
+
 The name of the branch has to be as follows:
 ```
 <issue-number>-<branch-name>
@@ -66,6 +70,7 @@ The name of the branch has to be as follows:
 
 ## Pull Requests (PRs)
 Make a pull request when you are completely done with your issue. Assign me as a reviewer & assignee, as the milestone choose the according milestone.
+
 ### 🗃️ PR message structure
 ---
 ```

--- a/docs/CONTRIBUTING.md
+++ b/docs/CONTRIBUTING.md
@@ -1,9 +1,24 @@
 # 📜 Conventions for contributions
-This file contains guidelines for creating *commits, PRs, branches, issues, and etc*. 
+This file contains guidelines for creating *commits, PRs, branches, issues, and etc*.
+
+## Index
+
+- [Commits](#➕-commits)
+  - [Commit Message Structure](#🗃️-commit-message-structure)
+  - [Example Commit](#example-commit)
+  - [Commit Types](#📑-commit-types)
+  - [Breaking Changes](#❗️-breaking-changes)
+- [Branching](#🌳-branching)
+  - [Example Branch Name](#📄-example-branch-name)
+- [Pull Requests (PRs)](#pull-requests-prs)
+  - [PR message structure](#🗃️-pr-message-structure)
+  - [Example PR Message](#📄-example-pr-message)
 
 > [!NOTE]  
 > **READ BEFORE CONTRIBUTING!**<br>
 > If you have any questions on the following information, text me (Adil), I will take you through it.
+
+---
 
 ## ➕ Commits
 First, let's answer the questions **"When do I commit? And how many files do I commit at once?"**
@@ -84,6 +99,7 @@ Closes Issue #number-of-the-issue
 
 ### 📄 Example PR message
 ---
+
 ```
 Login Page finished
 


### PR DESCRIPTION
With Alerts being supported on GitHub [recently](https://github.com/orgs/community/discussions/16925), this PR adds the updated markdown support to indicate the importance of the text.

Example:
> [!WARNING]  
> Critical content demanding immediate user attention due to potential risks.

Reference: https://github.com/orgs/community/discussions/16925